### PR TITLE
Fix output directory and path join

### DIFF
--- a/Download Online Videos
+++ b/Download Online Videos
@@ -1,9 +1,13 @@
 import yt_dlp
+import os
 
 def download_youtube_video(url, save_path):
     try:
+        # Ensure the output directory exists
+        os.makedirs(save_path, exist_ok=True)
+
         ydl_opts = {
-            'outtmpl': save_path + '/%(title)s.%(ext)s',
+            'outtmpl': os.path.join(save_path, '%(title)s.%(ext)s'),
             'format': 'best'
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
## Summary
- ensure output directory exists before downloading
- use `os.path.join` for the download template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c4bf3b194832a92cc7ca10cc0cecb